### PR TITLE
Wrap date string in parseISO

### DIFF
--- a/components/post.js
+++ b/components/post.js
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import Head from "next/head";
 import PropTypes from "prop-types";
 import React from "react";
@@ -77,7 +77,7 @@ function Post(props) {
 
       <HeroSection>
         <p className="mb-2 text-white tracking-widest uppercase">
-          {format(props.meta.date, `MMMM D, YYYY`)}
+          {format(parseISO(props.meta.date), `MMMM D, YYYY`)}
         </p>
         <h1 className="font-black leading-tight md:leading-normal mb-4 md:mb-0 text-4xl text-white">
           {props.meta.title}


### PR DESCRIPTION
To prepare for a breaking change in date-fns v2, wrap the string passed to `format` in `parseISO`.